### PR TITLE
Fix S3 list_objects_v2 errors

### DIFF
--- a/lib/aws/generated/s3.ex
+++ b/lib/aws/generated/s3.ex
@@ -3612,7 +3612,7 @@ defmodule AWS.S3 do
     else
       query_
     end
-    request(client, :get, path_, query_, headers, nil, options, nil)
+    request(client, :get, path_, query_, headers, %{}, options, nil)
   end
 
   @doc """
@@ -6389,7 +6389,7 @@ defmodule AWS.S3 do
   end
   defp add_query(url, query, client) do
     querystring = encode!(client, query, :query)
-    "#{url}?#{querystring}"
+    "#{url}&#{querystring}"
   end
 
   defp encode!(client, payload, format \\ :xml) do


### PR DESCRIPTION
This PR contains two fixes for the S3 client:

1. Sending an empty map instead of nil, to prevent parsing errors
2. Formatting the query string correctly.

To-Do

- [ ] Clean it up. i.e make it less hacky/more foolproof
- [ ] Ensure specs still wiork